### PR TITLE
Added overloaded animate function to accept more parameters.

### DIFF
--- a/src/js/elementTransitions.js
+++ b/src/js/elementTransitions.js
@@ -42,10 +42,23 @@ var PageTransitions = (function($) {
   }
 
   function animate(block, callback) {
-    var outClass = formatClass($(block).attr('et-out')),
-        inClass  = formatClass($(block).attr('et-in')),
-        step     = $(block).attr('et-step'),
-        block    = $(block).closest('.et-wrapper')
+    PageTransitions.animate(block, undefined, undefined, undefined, callback);
+  }
+
+  function animate(block, outClass, inClass, step, callback) {
+    if (outClass === undefined)
+      outClass = formatClass($(block).attr('et-out'));
+    else
+      outClass = formatClass(outClass);
+    if (inClass === undefined)
+      inClass  = formatClass($(block).attr('et-in'));
+    else
+      inClass = formatClass(inClass);
+
+    if (step === undefined) 
+      step = $(block).attr('et-step')
+    
+    var block    = $(block).closest('.et-wrapper')
 
     if (step === undefined)
       step = 1;


### PR DESCRIPTION
I needed to be able to have more control over the animate function. So
I'm passing in the inClass, outClass, and step as additional parameters.
I added this in an overloaded function so that all original setups will
continue to work correctly. This will allow me to call the function on
scroll and make it behave differently depending on how I scroll. Example
below using https://github.com/jquery/jquery-mousewheel.

```
$('body').mousewheel(function(event) {
 if (event.deltaY < 0)
  PageTransitions.animate($(".et-rotate"), "rotateCubeTopOut ontop", "rotateCubeTopIn", 1);
 else
  PageTransitions.animate($(".et-rotate"), "rotateCubeBottomOut ontop", "rotateCubeBottomIn", -1);
});
```
