### PR TITLE
Correct path to elementTransitions.css so example.html works

### DIFF
--- a/demo/example.html
+++ b/demo/example.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
-    <link rel="stylesheet" type="text/css" href="../build/elementTransitions.css" />
+    <link rel="stylesheet" type="text/css" href="../src/css/elementTransitions.css" />
     <script src="../build/elementTransitions.min.js"></script>
     <style>
       .et-wrapper {

--- a/demo/example.html
+++ b/demo/example.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
-    <link rel="stylesheet" type="text/css" href="../src/css/elementTransitions.css" />
+    <link rel="stylesheet" type="text/css" href="../build/elementTransitions.min.css" />
     <script src="../build/elementTransitions.min.js"></script>
     <style>
       .et-wrapper {


### PR DESCRIPTION
The demo/example.html file doesn't work because it can't find the CSS file.  This patch corrects the path.